### PR TITLE
Added missing posToNodeId method for Knight's Tour section of pythonds

### DIFF
--- a/pythonds/source/Graphs/BuildingtheKnightsTourGraph.rst
+++ b/pythonds/source/Graphs/BuildingtheKnightsTourGraph.rst
@@ -53,8 +53,7 @@ in :ref:`Figure 1 <fig_knightmoves>`.
         return ktGraph
 
     def posToNodeId(row, column, board_size):
-        board = [[(x + (y * 5)) for x in range(5)] for y in range(5)]
-        return board[row][column]
+        return (row * board_size) + column
 
 The ``genLegalMoves`` function (:ref:`Listing 2 <lst_knighttour2>`) takes the position of the knight on the
 board and generates each of the eight possible moves. The ``legalCoord``

--- a/pythonds/source/Graphs/BuildingtheKnightsTourGraph.rst
+++ b/pythonds/source/Graphs/BuildingtheKnightsTourGraph.rst
@@ -52,6 +52,10 @@ in :ref:`Figure 1 <fig_knightmoves>`.
                    ktGraph.addEdge(nodeId,nid)
         return ktGraph
 
+    def posToNodeId(row, column, board_size):
+        board = [[(x + (y * 5)) for x in range(5)] for y in range(5)]
+        return board[row][column]
+
 The ``genLegalMoves`` function (:ref:`Listing 2 <lst_knighttour2>`) takes the position of the knight on the
 board and generates each of the eight possible moves. The ``legalCoord``
 helper function (:ref:`Listing 2 <lst_knighttour2>`) makes sure that a particular move that is generated is


### PR DESCRIPTION
This method's code was missing although it was being used by other methods on the same page.